### PR TITLE
fix reup to reuse the same role

### DIFF
--- a/nd_okta_auth/aws.py
+++ b/nd_okta_auth/aws.py
@@ -165,6 +165,10 @@ class Session(object):
 
         return now < expiration_time
 
+    def update_assertion(self, assertion):
+        self.assertion = models.SamlAssertion(assertion)
+        return
+        
     def assume_role(self):
         """Use the SAML Assertion to actually get the credentials.
 

--- a/nd_okta_auth/main.py
+++ b/nd_okta_auth/main.py
@@ -158,11 +158,15 @@ def main(argv):
         try:
             assertion = okta_client.get_assertion(appid=config.appid,
                                                   apptype='amazon_aws')
-            if has_run_once:
+            if not session:
                 session = aws.Session(assertion, profile=config.name)
+            else:
+                session.update_assertion(assertion)
+
+            if has_run_once:
+                #session = aws.Session(assertion, profile=config.name)
                 session.assume_last_used_role()
             else:
-                session = aws.Session(assertion, profile=config.name)
                 session.assume_role()
         except KeyboardInterrupt:
             log.info('Exiting.')


### PR DESCRIPTION
fix crashes when attempting reup after an hour.

This will update the assertion of the current aws session instead of creating a new one every time.
